### PR TITLE
Array Validation Implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EasyJSONMatcher
 This project rocks (well, hopefully!) and uses MIT-LICENSE.
 
-version 0.0.0
+version 0.0.2
 
 This gem will assist developers who want to test that their API conforms to a given JSON schema
 
@@ -21,7 +21,7 @@ The gem should also allow the nesting of schemas, to avoid code reuse.
 Take the example response from the JSONAPi website's front page:
 
 ```ruby
-JSONMatcher::Schema.new :article do
+EasyJSONMatcher::SchemaGenerator.new :article do
 
     links :true
 

--- a/easy_json_matcher.gemspec
+++ b/easy_json_matcher.gemspec
@@ -11,9 +11,13 @@ Gem::Specification.new do |s|
   s.email       = ["wjdhamilton@hotmail.co.uk"]
   s.homepage    = "https://github.com/wjdhamilton/easy-json-matcher"
   s.summary     = "Easily test your JSON output with templates and Schemas"
-  s.description = "Test your JSON API with a simple set of classes, all written in Ruby. Simply define your JSON schemas and then pass the JSON to be tested to the schema's valid? method"
+  s.description = "TBC: Description of JsonapiMatcher."
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
+
+  s.add_dependency "rails", "~> 4.2.5.1"
+
+  s.add_development_dependency "sqlite3"
 end

--- a/lib/easy_json_matcher/array_validator.rb
+++ b/lib/easy_json_matcher/array_validator.rb
@@ -1,8 +1,53 @@
 require 'easy_json_matcher/validator'
 module EasyJSONMatcher
   class ArrayValidator < Validator
+    attr_reader :validators, :validator_results
+
     def _validate
+      return false unless _content_is_array?
+      _validate_content
+    end
+
+    def _content_is_array?
       content.is_a? Array
+    end
+
+    def _validate_content
+      validators.each do |val|
+        _run_validator(val)
+      end
+      _validation_result
+    end
+
+    def should_only_contain(type:,opts: {})
+      _clear_validators
+      _add_validator(_create_validator(type: type, opts: opts))
+    end
+
+    def _clear_validators
+      validators.clear
+    end
+
+    def _add_validator(validator)
+      validators << validator
+    end
+
+    def validators
+      @validators ||= []
+    end
+
+    def _run_validator(v)
+      content.each do |value|
+        validator_results << v.valid?(value)
+      end
+    end
+
+    def _validation_result
+      !validator_results.include? false
+    end
+
+    def validator_results
+      @validator_results ||= []
     end
   end
 end

--- a/lib/easy_json_matcher/date_validator.rb
+++ b/lib/easy_json_matcher/date_validator.rb
@@ -8,7 +8,7 @@ module EasyJSONMatcher
     def initialize(opts = {})
       super(opts)
       @date_format = opts[:format]
-      @string_validator = ValidatorFactory.create({type: :string})
+      @string_validator = _create_validator(type: :string)
     end
 
     def _validate

--- a/lib/easy_json_matcher/schema_generator.rb
+++ b/lib/easy_json_matcher/schema_generator.rb
@@ -20,13 +20,20 @@ module EasyJSONMatcher
     end
 
     def has_attribute(key:, opts: {})
-      node.add_validator(_create_validator(_validator_opts(key, opts)))
+      node.add_validator(_create_validator(key, opts))
     end
 
     def contains_schema(schema_name:, opts: {})
-      schema = SchemaLibrary.get_schema(schema_name)
+      schema = _create_validator(schema_name, opts)
       schema.key = opts[:key] || schema_name
       node.add_validator schema
+    end
+
+    def contains_array(key:, opts: {})
+      opts.merge!({type: :array})
+      array_validator = _create_validator(key, opts)
+      yield array_validator if block_given?
+      node.add_validator array_validator
     end
 
     def _validator_opts(key, opts)
@@ -34,8 +41,8 @@ module EasyJSONMatcher
       opts
     end
 
-    def _create_validator(opts)
-      ValidatorFactory.create opts
+    def _create_validator(key, opts)
+      ValidatorFactory.get_instance type: opts[:type], opts: _validator_opts(key, opts)
     end
 
     def _node_generator(opts = {})

--- a/lib/easy_json_matcher/validator.rb
+++ b/lib/easy_json_matcher/validator.rb
@@ -24,5 +24,9 @@ module EasyJSONMatcher
     def _check_required?
       required
     end
+
+    def _create_validator(type:, opts: {})
+      ValidatorFactory.get_instance(type: type, opts: opts)
+    end
   end
 end

--- a/lib/easy_json_matcher/validator_factory.rb
+++ b/lib/easy_json_matcher/validator_factory.rb
@@ -9,9 +9,13 @@ module EasyJSONMatcher
   class ValidatorFactory
 
     class << self
-      def create(opts)
-        validator_class = get_type(opts[:type])
-        validator_class.new options: opts
+      def get_instance(type:, opts: {})
+        if type == :schema
+          SchemaLibrary.get_schema(opts[:name])
+        else
+          validator_class = get_type(type)
+          validator_class.new options: opts
+        end
       end
 
       def get_type(name)

--- a/test/easy_json_matcher_test.rb
+++ b/test/easy_json_matcher_test.rb
@@ -81,10 +81,6 @@ class JsonapiMatcherTest < ActiveSupport::TestCase
     assert(!test_schema.valid?(invalid_json), "\"1\" is not a valid array value")
   end
 
-  test "As a user I want to be able to specify what should be found in an array" do
-    flunk "Implement me"
-  end
-
   test "As a user I want to be able to validate date values" do
     test_schema = EasyJSONMatcher::SchemaGenerator.new { |schema|
       schema.has_attribute(key: :date, opts: {type: :date})

--- a/test/validating_arrays_test.rb
+++ b/test/validating_arrays_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+class ValidatingArraysTest < ActiveSupport::TestCase
+
+  setup do
+    @test_schema = EasyJSONMatcher::SchemaGenerator.new { |s|
+      s.has_attribute(key: :name, opts: {type: :string})
+      s.contains_array(key: :items, opts: {required: true}) do |array|
+        array.should_only_contain(type: :string, opts: {required: true})
+      end
+    }.generate_node
+  end
+
+  test "As a user I want to validate that my arrays contain values of the correct type" do
+    valid_json = {
+      name: 'Greek Heroes',
+      items: ['Heracles', 'Perseus', 'Theseus', 'Achilles']
+    }.to_json
+
+    assert(@test_schema.valid?(valid_json), "#{valid_json} should have been valid")
+
+    invalid_no_items = {
+      name: 'Strictly Come Dancing Heroes'
+    }.to_json
+
+    assert_not(@test_schema.valid?(invalid_no_items), "#{invalid_no_items} should not have been valid as it has no array called items")
+
+    invalid_wrong_items = {
+      name: 'Prime Heroes',
+      items: [1,3,5,7,9,8191]
+    }.to_json
+
+    assert_not(@test_schema.valid?(invalid_wrong_items), "#{invalid_wrong_items} should not have been validated since the array contains the wrong type")
+  end
+
+  test "As a user I want to validate that my arrays can contain objects of a specific schema" do
+    EasyJSONMatcher::SchemaGenerator.new {|s|
+
+      s.has_attribute key: :name, opts: {type: :string, required: true}
+      s.has_attribute key: :spouse, opts: {type: :string}
+    }.register(schema_name: :greek_hero)
+
+    test_schema = EasyJSONMatcher::SchemaGenerator.new {|s|
+      s.contains_array(key: :data, opts: {required: true}) do |a|
+        a.should_only_contain(type: :schema, opts: {name: :greek_hero})
+      end
+    }.generate_node
+
+    valid_json = {
+      data: [{
+          name: 'Greek Heroes',
+          items: ['Hector', 'Ajax', 'Hippolyta', 'Penthesila']
+        },
+      {
+        name: 'Roman Heroes',
+        items: ['Romulus', 'Remus', 'Aeneus']
+        }]
+    }.to_json
+
+    assert(test_schema.valid?(valid_json), "#{valid_json} should have been validated as it follows the correct schema")
+
+    invalid_json = {
+      data: [1,2,3,4,5]
+    }
+
+    assert_not(test_schema.valid?(invalid_json), "#{invalid_json} should not have validated as it does not contain a :heroes schema")
+  end
+end


### PR DESCRIPTION
EAS-12 #time 46m #done
EAS-3 #comment users can now validate that an array contains items of a specific type. At this stage the functionality is quite limited. It can only validate that an Array contains 0..* of a single type of value, including Schemas
EAS-3 #comment should consider validating the number of items