### PR TITLE
Country Payload now validating

### DIFF
--- a/lib/easy_json_matcher/number_validator.rb
+++ b/lib/easy_json_matcher/number_validator.rb
@@ -6,7 +6,9 @@ module EasyJSONMatcher
       begin
         Kernel::Float(content)
         true
-      rescue ArgumentError => e
+      rescue ArgumentError
+        false
+      rescue TypeError
         false
       end
     end

--- a/lib/easy_json_matcher/schema_generator.rb
+++ b/lib/easy_json_matcher/schema_generator.rb
@@ -24,9 +24,20 @@ module EasyJSONMatcher
     end
 
     def contains_schema(schema_name:, opts: {})
-      schema = _create_validator(schema_name, opts)
-      schema.key = opts[:key] || schema_name
+      key = opts[:key] || schema_name
+      schema = _create_validator(key, _prep_schema_opts(schema_name, opts))
+      _set_validator_key(schema, opts[:key] || schema_name)
       node.add_validator schema
+    end
+
+    def _prep_schema_opts(schema_name, opts)
+      opts[:type] = :schema
+      opts[:name] = schema_name
+      opts
+    end
+
+    def _set_validator_key(validator, key)
+      validator.key = key
     end
 
     def contains_array(key:, opts: {})

--- a/lib/easy_json_matcher/schema_library.rb
+++ b/lib/easy_json_matcher/schema_library.rb
@@ -22,7 +22,13 @@ module EasyJSONMatcher
       end
 
       def get_schema(name)
-        SCHEMAS[name] or raise MissingSchemaException.new("No schema with #{name} has been registered")
+         _find_and_clone_schema(name) or raise MissingSchemaException.new("No schema with #{name} has been registered")
+      end
+
+      def _find_and_clone_schema(name)
+        s = SCHEMAS[name]
+        return s.dup if s
+        nil
       end
     end
   end

--- a/lib/easy_json_matcher/validator_factory.rb
+++ b/lib/easy_json_matcher/validator_factory.rb
@@ -10,6 +10,7 @@ module EasyJSONMatcher
 
     class << self
       def get_instance(type:, opts: {})
+        raise "Type must be specified" unless type
         if type == :schema
           SchemaLibrary.get_schema(opts[:name])
         else

--- a/test/easy_json_matcher_test.rb
+++ b/test/easy_json_matcher_test.rb
@@ -25,7 +25,7 @@ class JsonapiMatcherTest < ActiveSupport::TestCase
   test "As a user I want to be able to validate numbers" do
 
     test_schema = EasyJSONMatcher::SchemaGenerator.new {|schema|
-      schema.has_attribute(key: :number, opts: {type: :number})
+      schema.has_attribute(key: :number, opts: {type: :number, required: :true})
     }.generate_node
 
     valid_json = {
@@ -38,6 +38,11 @@ class JsonapiMatcherTest < ActiveSupport::TestCase
       number: "hi"
     }.to_json
     assert_not(test_schema.valid?(invalid_json), "\"hi\" should not have been valid")
+
+    invalid_nil = {
+      number: nil
+    }.to_json
+    assert_not(test_schema.valid?(invalid_nil), "#{invalid_nil} should not have validated, or thrown an error")
   end
 
   test "As a user I want to be able to validate booleans" do


### PR DESCRIPTION
Why: Country payload did not validate properly because of a bug in SchemaGenerator.
EAS-15 #comment SchemaGenerator did not add the correct key to the schema when it was retrieved from the library. This has been corrected.
A side effect of this specific bug was discovering that ArrayValidator did not handle nil values correctly - it threw a type error instead of returning false
EAS-16 #done ArrayValidator refactored to handle TypeError as well as ArgumentError
As an additional bonus I have also refactored SchemaLibrary to return a copy of any schemas requested rather than the original.