### PR TITLE
Removed cotains_schema and passed responsibility to has_attribute

### DIFF
--- a/lib/easy_json_matcher/schema_generator.rb
+++ b/lib/easy_json_matcher/schema_generator.rb
@@ -23,13 +23,6 @@ module EasyJSONMatcher
       node.add_validator(_create_validator(key, opts))
     end
 
-    def contains_schema(schema_name:, opts: {})
-      key = opts[:key] || schema_name
-      schema = _create_validator(key, _prep_schema_opts(schema_name, opts))
-      _set_validator_key(schema, opts[:key] || schema_name)
-      node.add_validator schema
-    end
-
     def _prep_schema_opts(schema_name, opts)
       opts[:type] = :schema
       opts[:name] = schema_name

--- a/lib/easy_json_matcher/schema_library.rb
+++ b/lib/easy_json_matcher/schema_library.rb
@@ -21,14 +21,20 @@ module EasyJSONMatcher
         SCHEMAS
       end
 
-      def get_schema(name)
-         _find_and_clone_schema(name) or raise MissingSchemaException.new("No schema with #{name} has been registered")
+      def get_schema(name:, opts: {})
+         schema = _find_and_clone_schema(name) or raise MissingSchemaException.new("No schema with #{name} has been registered")
+        _set_schema_key(schema, opts[:key])
+        schema
       end
 
       def _find_and_clone_schema(name)
         s = SCHEMAS[name]
         return s.dup if s
         nil
+      end
+
+      def _set_schema_key(schema, key)
+        schema.key = key
       end
     end
   end

--- a/lib/easy_json_matcher/validator_factory.rb
+++ b/lib/easy_json_matcher/validator_factory.rb
@@ -12,7 +12,7 @@ module EasyJSONMatcher
       def get_instance(type:, opts: {})
         raise "Type must be specified" unless type
         if type == :schema
-          SchemaLibrary.get_schema(opts[:name])
+          SchemaLibrary.get_schema(name: opts[:name], opts: opts)
         else
           validator_class = get_type(type)
           validator_class.new options: opts

--- a/test/managing_schemas_test.rb
+++ b/test/managing_schemas_test.rb
@@ -18,20 +18,20 @@ class ManagingSchemasTest < ActiveSupport::TestCase
       name: 'Green Mandarin'
     }.to_json
 
-    schema = EasyJSONMatcher::SchemaLibrary.get_schema(@name)
+    schema = EasyJSONMatcher::SchemaLibrary.get_schema(name: @name)
     assert(schema.valid?(test_schema), "test_schema did not validate correctly")
   end
 
   test "SchemaLibrary should thrown a MissingSchemaException if an unregistered schema is requested" do
     assert_raises(EasyJSONMatcher::MissingSchemaException) do
-      EasyJSONMatcher::SchemaLibrary.get_schema("#{@name.to_s}-wibble")
+      EasyJSONMatcher::SchemaLibrary.get_schema(name: "#{@name.to_s}-wibble")
     end
   end
 
   test "As a user I want to reuse a schema within another schema" do
     test_schema = EasyJSONMatcher::SchemaGenerator.new { |s|
       s.has_attribute(key: :is_present, opts: {type: :boolean, required: true})
-      s.contains_schema(schema_name: @name)
+      s.has_attribute(key: @name, opts: {name: @name, type: :schema})
     }.generate_node
 
     invalid_json = {
@@ -57,12 +57,12 @@ class ManagingSchemasTest < ActiveSupport::TestCase
     }.register(schema_name: :country)
 
     EasyJSONMatcher::SchemaGenerator.new {|country_payload|
-      country_payload.contains_schema(schema_name: :country, opts: {key: :data})
+      country_payload.has_attribute(key: :data, opts: {name: :country, type: :schema})
     }.register(schema_name: :country_payload)
 
     valid_json = "{\"data\":{\"id\":\"4376\",\"type\":\"countries\",\"attributes\":{\"alpha_2\":\"GB\",\"alpha_3\":\"GBR\",\"name\":\"United Kingdom of Great Britain and Northern Ireland\"}}}"
 
-    validator = EasyJSONMatcher::SchemaLibrary.get_schema(:country_payload)
+    validator = EasyJSONMatcher::SchemaLibrary.get_schema(name: :country_payload)
     assert(validator.valid? valid_json)
   end
 end


### PR DESCRIPTION
Why:
The contains_schema method explicitly set the key on the retrieved schema procured from ValidatorFactory. This was because a schema, when retrieved from the library had no key set. This was a developer-induced dependency: I knew that the schemas in the schema library had no key, so I passed that knowledge on to SchemaGenerator.

This change addresses the need by: Removing the contains_schema method from SchemaGenerator and stipulating that type: :schema and name: <name> must be added to the opts hash. ValidatoryFactory now handles the interface with SchemaLibrary, and SchemaLibrary now handles setting the key on the schema. This is not yet perfect, but moves the dependency for key a lot closer to the schema instance that is to be used.