### PR TITLE
Array Error Messages Refined

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easy_json_matcher (0.0.2)
+    easy_json_matcher (0.0.4)
       rails (~> 4.2.5.1)
 
 GEM
@@ -93,7 +93,7 @@ GEM
       activesupport (= 4.2.5.2)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.5.0)
+    rake (11.1.1)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/lib/easy_json_matcher.rb
+++ b/lib/easy_json_matcher.rb
@@ -1,6 +1,5 @@
 require 'easy_json_matcher/node'
 require 'easy_json_matcher/schema_generator'
 module EasyJSONMatcher
-  #Try out Hound
 
 end

--- a/lib/easy_json_matcher/array_validator.rb
+++ b/lib/easy_json_matcher/array_validator.rb
@@ -50,7 +50,7 @@ module EasyJSONMatcher
 
     def _validate_content
       validators.each do |val|
-        _run_validator(val)
+        _accumulate_errors val
       end
     end
 
@@ -66,12 +66,15 @@ module EasyJSONMatcher
       @validators ||= []
     end
 
-    def _run_validator(v)
-      content.each do |value|
-        unless v.valid?(value)
-          errors << v.errors
-        end
+    def _accumulate_errors(validator)
+      content.each do |candidate|
+        _run_validator(validator, candidate)
       end
+      errors << validator.errors unless validator._no_errors?
+    end
+
+    def _run_validator(validator, candidate)
+      validator.valid? candidate
     end
 
     def _validation_result

--- a/test/error_messages_test.rb
+++ b/test/error_messages_test.rb
@@ -13,8 +13,6 @@ class ErrorMessagesTest < ActiveSupport::TestCase
       end
     }.generate_schema
 
-    # This JSON only reflects the structure of the above, it's validity is rendered
-    # irrelevant by the monkey-patch of Validator
     has_errors = {
       oops: 1,
       ok: 'ok',
@@ -50,6 +48,24 @@ class ErrorMessagesTest < ActiveSupport::TestCase
     assert_not(test_schema.valid? wrong_type)
 
     assert_match(/.*is not an Array/, test_schema.get_errors[:arr][0])
+  end
+
+  test "As a user, given that I have specified that an array should contain a specific
+        type of value and the array contains other types of value, I want to know which
+        value was the wrong type and why" do
+
+        test_schema = EasyJSONMatcher::SchemaGenerator.new {|s|
+          s.contains_array key: :array do |a|
+            a.should_only_contain type: :string
+          end
+        }.generate_schema
+
+        episodes_where_sheldon_says_bazinga_in_series_2 = {
+          array: [1,2,3]
+        }.to_json
+
+        assert_not(test_schema.valid? episodes_where_sheldon_says_bazinga_in_series_2)
+        assert_match(/.* is not a String/, test_schema.get_errors[:array][0][0])
   end
 
   test "As a user, given that I have specified that a boolean should map to a given


### PR DESCRIPTION
Although Array did provide a useful error message if its content was invalid, the message itself was flawed since the same message was added multiple times.
This fix addresses the need by ensuring that each error is only added once per item in the array.