### PR TITLE
Validation is now Stateless

### DIFF
--- a/lib/easy_json_matcher/array_content_validator.rb
+++ b/lib/easy_json_matcher/array_content_validator.rb
@@ -7,9 +7,10 @@ module EasyJSONMatcher
       @verifier = verify_with
     end
 
-    def check(value:, errors: [])
+    def check(value:)
+      errors = []
       value.each do |val|
-        break unless verifier.check(value: val, errors: errors)
+        errors = errors + verifier.check(value: val)
       end
       errors
     end

--- a/lib/easy_json_matcher/array_content_validator.rb
+++ b/lib/easy_json_matcher/array_content_validator.rb
@@ -10,7 +10,7 @@ module EasyJSONMatcher
     def check(value:)
       errors = []
       value.each do |val|
-        errors = errors + verifier.check(value: val)
+        errors += verifier.check(value: val)
       end
       errors
     end

--- a/lib/easy_json_matcher/node.rb
+++ b/lib/easy_json_matcher/node.rb
@@ -11,8 +11,8 @@ module EasyJSONMatcher
       @node_validator.concat(@validators)
     end
 
-    def check(value:, errors:[])
-      node_validator.check(value: value, errors: errors)
+    def check(value:)
+      node_validator.check(value: value)
     end
   end
 end

--- a/lib/easy_json_matcher/validation_step.rb
+++ b/lib/easy_json_matcher/validation_step.rb
@@ -15,9 +15,9 @@ module EasyJSONMatcher
     def check(value:)
       errors = []
       if verifier.call(value, errors) == false || is_tail?
-         errors
+        errors
       else
-         errors + next_step.check(value: value)
+        errors + next_step.check(value: value)
       end
     end
 
@@ -26,11 +26,7 @@ module EasyJSONMatcher
     end
 
     def concat(chain)
-      if is_tail?
-        self.>> chain
-      else
-        next_step.concat(chain)
-      end
+      is_tail? ? self.>> chain : next_step.concat(chain)
     end
 
     def is_tail?

--- a/lib/easy_json_matcher/validation_step.rb
+++ b/lib/easy_json_matcher/validation_step.rb
@@ -15,9 +15,9 @@ module EasyJSONMatcher
     def check(value:)
       errors = []
       if verifier.call(value, errors) == false || is_tail?
-        return errors
+         errors
       else
-        return errors + next_step.check(value: value)
+         errors + next_step.check(value: value)
       end
     end
 

--- a/lib/easy_json_matcher/validation_step.rb
+++ b/lib/easy_json_matcher/validation_step.rb
@@ -12,11 +12,12 @@ module EasyJSONMatcher
       @verifier = verify_with
     end
 
-    def check(value:, errors: [])
+    def check(value:)
+      errors = []
       if verifier.call(value, errors) == false || is_tail?
         return errors
       else
-        return next_step.check(value: value, errors: errors)
+        return errors + next_step.check(value: value)
       end
     end
 

--- a/lib/easy_json_matcher/validation_step.rb
+++ b/lib/easy_json_matcher/validation_step.rb
@@ -26,7 +26,7 @@ module EasyJSONMatcher
     end
 
     def concat(chain)
-      is_tail? ? self.>> chain : next_step.concat(chain)
+      is_tail? ? self.>>(chain) : next_step.concat(chain)
     end
 
     def is_tail?

--- a/test/validation_step_not_required_test.rb
+++ b/test/validation_step_not_required_test.rb
@@ -18,7 +18,7 @@ module EasyJSONMatcher
       it "should allow the chain to continue if the value is present" do
         head, tail = get_validation_chain
         test_value = 1
-        tail.expect(:check, nil, [{value: 1, errors: []}])
+        tail.expect(:check, [], [{ value: 1 }])
         tail.expect(:nil?, false)
         head.check(value: test_value)
         tail.verify

--- a/test/validation_step_test.rb
+++ b/test/validation_step_test.rb
@@ -18,7 +18,7 @@ module EasyJSONMatcher
       tail = MiniTest::Mock.new
       test_value = "hello!"
       head >> tail
-      tail.expect(:check, nil, [Hash])
+      tail.expect(:check, [], [Hash])
       tail.expect(:nil?, false)
       head.check(value: test_value)
       tail.verify


### PR DESCRIPTION
Why: State is a pain, especially if it changes. You have objects flying
around which can be in an inconsistent state. This problem has already
been seen in early versions of the gem where a reset! method was added
to clear error messages.

The fix addresses the need by:
Recursively building up the error array from the lowest points in the
verification tree.