### PR TITLE
Added use_schema to SchemaLibrary interface

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easy_json_matcher (0.3.0)
+    easy_json_matcher (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/easy_json_matcher/schema_library.rb
+++ b/lib/easy_json_matcher/schema_library.rb
@@ -24,6 +24,10 @@ module EasyJSONMatcher
         schema
       end
 
+      def use_schema(name:, wrap_with: Validator)
+        wrap_with.new validate_with: SCHEMAS[name]
+      end
+
       def _find_and_clone_schema(name)
         s = SCHEMAS[name]
         return s.dup if s or nil

--- a/test/managing_schemas_test.rb
+++ b/test/managing_schemas_test.rb
@@ -19,7 +19,7 @@ module EasyJSONMatcher
       candidate = {
         name: "Green Mandarin"
       }.to_json
-      schema = Validator.new validate_with: SchemaLibrary.get_schema(name: @name)
+      schema = SchemaLibrary.use_schema(name: @name)
       assert(schema.valid?(candidate: candidate), "test_schema did not validate correctly")
     end
 


### PR DESCRIPTION
In my rush to get all the tests to pass, I had manually wrapped the
schema with a `Validator` instance that is used in "As a user I want to
reuse a saved schema" which undermines the point of having a DSL.

This fix adds the `use_schema` method to `SchemaLibrary` so that a
wrapper instance is returned. This is the correct way to retrieve a
schema for reuse outwith another schema.