### PR TITLE
Gem now uses instance_eval

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,41 +2,38 @@ PATH
   remote: .
   specs:
     easy_json_matcher (0.3.4)
-      dry-auto_inject (~> 0.3)
-      dry-container (~> 0.3)
+      dry-auto_inject (~> 0.3.0)
+      dry-container (~> 0.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5.2)
+    activesupport (5.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    byebug (8.2.2)
-    concurrent-ruby (1.0.2)
-    debug_inspector (0.0.2)
+    byebug (9.0.6)
+    concurrent-ruby (1.0.5)
+    debug_inspector (0.0.3)
     dry-auto_inject (0.3.0)
       dry-container (~> 0.3.4)
-    dry-configurable (0.1.6)
+    dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
     dry-container (0.3.4)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    i18n (0.7.0)
-    json (1.8.3)
+    i18n (0.8.4)
     metaclass (0.0.4)
-    minitest (5.8.4)
-    mocha (1.1.0)
+    minitest (5.10.2)
+    mocha (1.2.1)
       metaclass (~> 0.0.1)
     pretty_backtrace (0.1.3)
       debug_inspector (~> 0.0.1)
-    rake (11.1.1)
-    rdoc (4.2.2)
-      json (~> 1.4)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    rake (12.0.0)
+    rdoc (5.1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -52,4 +49,4 @@ DEPENDENCIES
   rdoc
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/easy_json_matcher.gemspec
+++ b/easy_json_matcher.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   # Runtime dependencies
-  s.add_runtime_dependency 'dry-auto_inject', '~> 0.3'
-  s.add_runtime_dependency 'dry-container', '~>0.3'
+  s.add_runtime_dependency 'dry-auto_inject', '~> 0.3.0'
+  s.add_runtime_dependency 'dry-container', '~> 0.3.0'
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]

--- a/lib/easy_json_matcher.rb
+++ b/lib/easy_json_matcher.rb
@@ -7,4 +7,5 @@ module EasyJSONMatcher
 
   TYPES = [:number, :object, :value, :string, :boolean, :date, :array]
 
+  IMPORT = Dry::AutoInject(Container)
 end

--- a/lib/easy_json_matcher/node_generator.rb
+++ b/lib/easy_json_matcher/node_generator.rb
@@ -24,15 +24,14 @@ module EasyJSONMatcher
       validators[key] = validator.generate_attribute
     end
 
-    def contains_node(key:, opts: [])
-      generator = self.class.new(opts: opts, global_opts: global_opts)
-      yield generator if block_given?
+    def contains_node(key:, opts: [], &block)
+      generator = self.class.new(opts: opts, global_opts: global_opts, &block)
       validators[key] = generator.generate_node
     end
 
-    def contains_array(key:, opts: [])
+    def contains_array(key:, opts: [], &block)
       validator = array_generator.new(local_opts: opts, global_opts: global_opts)
-      yield validator if block_given?
+      validator.instance_eval &block if block_given?
       validators[key] = validator.generate_array
     end
 

--- a/lib/easy_json_matcher/schema_generator.rb
+++ b/lib/easy_json_matcher/schema_generator.rb
@@ -12,52 +12,17 @@ module EasyJSONMatcher
 
     attr_reader :node, :glob_opts, :att_glob_opts
 
-    def initialize(opts: [], global_opts: [], **args)
+    def initialize(opts: [], global_opts: [], **args, &block)
       super(**args)
       @glob_opts = global_opts
       @att_glob_opts = glob_opts.dup
       @att_glob_opts.delete(:strict)
       @node = new_node_generator(opts: opts, globals: global_opts)
-      yield node if block_given?
+      node.instance_eval &block if block_given?
     end
 
     def create_node(opts:)
       node.new(opts: opts)
-    end
-
-    def has_attribute(key:, opts:)
-      opts = override_globals(local_opts: opts)
-      opts = opts - [:strict]
-      validator = validation_chain_factory.get_chain(steps: opts)
-      node.add_validator key: key, validator: validator
-    end
-
-    # TODO pretty hacky but can be cleaned later
-    def override_globals(local_opts:)
-      if local_opts.include?(:not_required) && glob_opts.include?(:required)
-         (local_opts + (glob_opts - [:required]))
-      else
-        local_opts + glob_opts
-      end
-    end
-
-    ################ Methods for adding specific attribute types ##############
-
-    def contains_node(key:, opts: [])
-      generator = new_node_generator(opts: opts)
-      yield generator if block_given?
-      node.add_validator key: key, validator: generator.node
-    end
-
-    def contains_array(key:, opts: [], with_content:)
-      array_validator = array_validator.new opts: opts, verify_content_as: with_content
-      yield array_validator if block_given?
-      node.add_validator key: key, validator: array_validator
-    end
-
-    def has_schema(key:, name:)
-      schema = schema_library.get_schema(name: name)
-      node.add_validator key: key, validator: schema
     end
 
     ################ Methods for generating the schema #########################

--- a/test/custom_validations_test.rb
+++ b/test/custom_validations_test.rb
@@ -5,8 +5,8 @@ module EasyJSONMatcher
   describe "Custom Validations" do
 
     subject { 
-      SchemaGenerator.new { |sc|
-        sc.has_attribute key: "val", 
+      SchemaGenerator.new {
+        has_attribute key: "val", 
           opts: [
             :required,
             ->(value, errors) { errors << "value was false" unless value === true }

--- a/test/global_validation_options_test.rb
+++ b/test/global_validation_options_test.rb
@@ -6,11 +6,11 @@ module EasyJSONMatcher
 
 
     subject {  
-      SchemaGenerator.new(global_opts: [ :required ]) { |schema|
-        schema.has_boolean key: "implicitly_required"
-        schema.contains_node key: "also_implicitly_required" do |n|
-          n.has_boolean key: "nested_implicitly_required"
-          n.has_boolean key: "not_required", opts: [:not_required]
+      SchemaGenerator.new(global_opts: [ :required ]) {
+        has_boolean key: "implicitly_required"
+        contains_node key: "also_implicitly_required" do 
+          has_boolean key: "nested_implicitly_required"
+          has_boolean key: "not_required", opts: [:not_required]
         end
       }.generate_schema
     }

--- a/test/managing_schemas_test.rb
+++ b/test/managing_schemas_test.rb
@@ -6,9 +6,10 @@ module EasyJSONMatcher
 
     setup do
       @name = :test
-      SchemaGenerator.new { |schema|
-        schema.has_attribute(key: "name", opts: [ :string, :required ])
-      }.register(as: @name)
+      sc = SchemaGenerator.new { 
+        has_attribute(key: "name", opts: [ :string, :required ])
+      }
+      sc.register(as: @name)
     end
 
     test "As a user I want to be able to register a Schema so I can reuse it later" do
@@ -16,12 +17,12 @@ module EasyJSONMatcher
     end
 
     test "The order in which schemas are defined should not matter" do
-      test_schema = SchemaGenerator.new { |sc|
-        sc.has_schema key: "lazy", name: :lazily_evaluated
+      test_schema = SchemaGenerator.new { 
+        has_schema key: "lazy", name: :lazily_evaluated
       }.register as: :outer
 
-      lazy = SchemaGenerator.new { |sc|
-        sc.has_attribute key: "val"
+      SchemaGenerator.new {
+        has_attribute key: "val"
       }.register as: :lazily_evaluated
 
       valid_json = {
@@ -58,9 +59,9 @@ module EasyJSONMatcher
     end
 
     test "As a user I want to reuse a schema within another schema" do
-      test_schema = SchemaGenerator.new { |s|
-        s.has_boolean key: "is_present", opts: [ :required ]
-        s.has_schema key: @name, name: @name
+      test_schema = SchemaGenerator.new {
+        has_boolean key: "is_present", opts: [ :required ]
+        has_schema key: :test, name: :test
       }.generate_schema
 
       invalid_json = {
@@ -76,17 +77,17 @@ module EasyJSONMatcher
     end
 
     test "It can validate JSON Schema payloads" do
-      SchemaGenerator.new { |country|
-        country.has_attribute key: "id", opts: [:number, :required]
-        country.contains_node(key: "attributes") do |atts|
-          atts.has_attribute key: "alpha_2",  opts: [ :string, :required ]
-          atts.has_attribute key: "alpha_3",  opts: [ :string, :required ]
-          atts.has_attribute key: "name",     opts: [ :string, :required ]
+      SchemaGenerator.new { 
+        has_attribute key: "id", opts: [:number, :required]
+        contains_node(key: "attributes") do 
+          has_attribute key: "alpha_2",  opts: [ :string, :required ]
+          has_attribute key: "alpha_3",  opts: [ :string, :required ]
+          has_attribute key: "name",     opts: [ :string, :required ]
         end
       }.register(as: :country)
 
-      country_payload = SchemaGenerator.new {|country_payload|
-        country_payload.has_schema(key: "data", name: :country)
+      country_payload = SchemaGenerator.new {
+        has_schema(key: "data", name: :country)
       }.register(as: :country_payload)
 
       valid_json = "{\"data\":{\"id\":\"4376\",\"type\":\"countries\",\"attributes\":{\"alpha_2\":\"GB\",\"alpha_3\":\"GBR\",\"name\":\"United Kingdom of Great Britain and Northern Ireland\"}}}"

--- a/test/primitives_boolean_test.rb
+++ b/test/primitives_boolean_test.rb
@@ -9,8 +9,8 @@ module EasyJSONMatcher
   describe "Boolean Primitive Test" do
 
     before do
-      @test_schema = SchemaGenerator.new { |g|
-        g.has_boolean key: "boolean"
+      @test_schema = SchemaGenerator.new {
+        has_boolean key: "boolean"
       }.generate_schema
     end
 

--- a/test/primitives_date_test.rb
+++ b/test/primitives_date_test.rb
@@ -10,8 +10,8 @@ module EasyJSONMatcher
   describe "Date primitive" do
 
     before do
-      @test_schema = SchemaGenerator.new { |g|
-        g.has_date key: "date"
+      @test_schema = SchemaGenerator.new {
+        has_date key: "date"
       }.generate_schema
     end
 

--- a/test/primitives_number_test.rb
+++ b/test/primitives_number_test.rb
@@ -9,8 +9,8 @@ module EasyJSONMatcher
   describe "Number Validations" do
 
     before do
-      @test_schema = SchemaGenerator.new { |g|
-        g.has_number key: "number"
+      @test_schema = SchemaGenerator.new {
+        has_number key: "number"
       }.generate_schema
     end
 

--- a/test/primitives_object_test.rb
+++ b/test/primitives_object_test.rb
@@ -9,8 +9,8 @@ module EasyJSONMatcher
   describe "Object primitive test" do
 
     before do
-      @test_schema = SchemaGenerator.new { |g|
-        g.has_object key: "object"
+      @test_schema = SchemaGenerator.new {
+        has_object key: "object"
       }.generate_schema
     end
 

--- a/test/primitives_string_test.rb
+++ b/test/primitives_string_test.rb
@@ -9,8 +9,8 @@ module EasyJSONMatcher
   describe "Primitive String Validation" do
 
     before do
-      @test_schema = SchemaGenerator.new { |g|
-        g.has_string key: "string"
+      @test_schema = SchemaGenerator.new {
+        has_string key: "string"
       }.generate_schema
     end
 

--- a/test/primtives_value_test.rb
+++ b/test/primtives_value_test.rb
@@ -9,8 +9,8 @@ module EasyJSONMatcher
   describe "Value primitive test" do
 
     before do
-      @test_schema = SchemaGenerator.new { |g|
-        g.has_boolean key: :value
+      @test_schema = SchemaGenerator.new {
+        has_boolean key: :value
       }.generate_schema
     end
 

--- a/test/required_validation_test.rb
+++ b/test/required_validation_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class RequireValidationTest < ActiveSupport::TestCase
 
   test "As a user I want to insist that a value is present" do
-    astronaut_schema = EasyJSONMatcher::SchemaGenerator.new { |s|
-      s.has_attribute key: "has_oxygen", opts: [:boolean, :required]
-      s.has_attribute key: "name", opts: [:string]
+    astronaut_schema = EasyJSONMatcher::SchemaGenerator.new {
+      has_attribute key: "has_oxygen", opts: [:boolean, :required]
+      has_attribute key: "name", opts: [:string]
     }.generate_schema
 
     valid_astronaut = {
@@ -23,9 +23,9 @@ class RequireValidationTest < ActiveSupport::TestCase
   end
 
   test "As a user I want validations to pass if the value is not present and I have not required it to be there" do
-    astronaut_schema = EasyJSONMatcher::SchemaGenerator.new { |s|
-      s.has_attribute key: "has_oxygen", opts: [:boolean]
-      s.has_attribute key: "name", opts: [:string]
+    astronaut_schema = EasyJSONMatcher::SchemaGenerator.new {
+      has_attribute key: "has_oxygen", opts: [:boolean]
+      has_attribute key: "name", opts: [:string]
     }.generate_schema
 
     valid_astronaut = {

--- a/test/strict_mode_test.rb
+++ b/test/strict_mode_test.rb
@@ -5,9 +5,9 @@ module EasyJSONMatcher
   describe "Strict Mode" do
 
     subject {
-      SchemaGenerator.new(global_opts: [ :strict ]) { |s|
-        s.has_attribute key: "a", opts: []
-        s.has_attribute key: "b", opts: []
+      SchemaGenerator.new(global_opts: [ :strict ]) {
+        has_attribute key: "a", opts: []
+        has_attribute key: "b", opts: []
       }.generate_schema
     }
 

--- a/test/validating_arrays_test.rb
+++ b/test/validating_arrays_test.rb
@@ -6,24 +6,24 @@ module EasyJSONMatcher
   describe ArrayValidator do
 
     before do
-      SchemaGenerator.new {|s|
-        s.has_attribute key: "name", opts: [:string, :required]
-        s.has_attribute key: "spouse", opts: [:string, :required]
+      SchemaGenerator.new {
+        has_attribute key: "name", opts: [:string, :required]
+        has_attribute key: "spouse", opts: [:string, :required]
       }.register as: :greek_hero
     end 
 
     subject{
-      test_schema = SchemaGenerator.new {|s|
-        s.contains_array(key: "data") do |a|
-          a.elements_should be: [:greek_hero]
+      SchemaGenerator.new {
+        contains_array(key: "data") do 
+          elements_should be: [:greek_hero]
         end
       }.generate_schema
     }
 
     it "should validate each value in the array" do
-      validator = SchemaGenerator.new { |s|
-        s.contains_array(key: "array") do |a|
-          a.elements_should be: [:number]
+      validator = SchemaGenerator.new {
+        contains_array(key: "array") do
+          elements_should be: [:number]
         end
       }.generate_schema
       candidate = { array: [1,2,3,4,"oops"] }.to_json


### PR DESCRIPTION
Also removed various bits of redundant code.

The gem now uses instance_eval so that the syntax is slightly nicer:

```ruby
SchemaGenerator.new do
  string key: "string"
end
```